### PR TITLE
[fix] Added First Class Pilot Text

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -32,7 +32,7 @@
       "services": {
         "header": "Services",
         "ImmigrationMedicalExams": "Immigration Medical Exams",
-        "FAAPhysicals": "FAA Physicals (2nd & 3rd Class, No Basic Med)",
+        "FAAPhysicals": "FAA Physicals (1st, 2nd & 3rd Class, No Basic Med)",
         "DOTPhysicals": "DOT Physicals",
         "schoolSportsCampPhysicals": "School/Sports/Camp Physicals"
       },
@@ -79,7 +79,7 @@
             "description": "USCIS-designated civil surgeon performing immigration medical exams."
           },
           "faaPhysicals": {
-            "title": "FAA Physicals (2nd & 3rd Class, No Basic Med)",
+            "title": "FAA Physicals (1st, 2nd & 3rd Class, No Basic Med)",
             "description": "FAA-designated aviation medical examiner performing pilot physicals."
           },
           "dotPhysicals": {
@@ -186,7 +186,7 @@
           }
         },
         "faaPhysicals": {
-          "title": "FAA Physicals (2nd & 3rd Class, No Basic Med)",
+          "title": "FAA Physicals (1st, 2nd & 3rd Class, No Basic Med)",
           "shortDescription": "The Federal Aviation Administration (FAA) requires pilots to be medically certified for their desired class of pilot certificate so that potential medical issues can be identified and addressed to prevent accidents and improve aviation safety.",
           "informationSection": {
             "whoApplies": {
@@ -487,8 +487,8 @@
                 ]
               },
               "faa": {
-                "title": "FAA Aviation Medical Examination (2nd & 3rd Class)",
-                "description": "Federal Aviation Administration medical certification examination for private and commercial pilots. We provide 2nd and 3rd class medical certificates.",
+                "title": "FAA Aviation Medical Examination (1st, 2nd & 3rd Class)",
+                "description": "Federal Aviation Administration medical certification examination for private and commercial pilots. We provide 1st, 2nd, and 3rd class medical certificates.",
                 "remindersList": [
                   "Make sure to bring: Current photo ID (Driver’s license or Passport), Contacts/glasses (if applicable) – If you wear contacts, bring a contact case to remove contacts to check uncorrected vision, Hearing aids (if applicable), Pertinent medical or legal records (if applicable), MedXPress confirmation number",
                   "Be sure to update your health history and current medications in MedXPress prior to your arrival.",

--- a/dictionaries/es.json
+++ b/dictionaries/es.json
@@ -32,7 +32,7 @@
       "services": {
         "header": "Servicios",
         "ImmigrationMedicalExams": "Exámenes Médicos de Inmigración",
-        "FAAPhysicals": "Exámenes Médicos de la FAA (2da y 3ra Clase, Sin Basic Med)",
+        "FAAPhysicals": "Exámenes Médicos de la FAA (1ra, 2da y 3ra Clase, Sin Basic Med)",
         "DOTPhysicals": "Exámenes Médicos del DOT",
         "schoolSportsCampPhysicals": "Exámenes Físicos Escolares, Deportivos y de Campamento"
       },
@@ -79,7 +79,7 @@
             "description": "Cirujana civil designada por el USCIS que realiza exámenes médicos de inmigración."
           },
           "faaPhysicals": {
-            "title": "Exámenes Médicos de la FAA (2da y 3ra Clase, Sin Basic Med)",
+            "title": "Exámenes Médicos de la FAA (1ra, 2da y 3ra Clase, Sin Basic Med)",
             "description": "Examinadora médica de aviación designada por la FAA que realiza exámenes médicos para pilotos."
           },
           "dotPhysicals": {
@@ -186,7 +186,7 @@
           }
         },
         "faaPhysicals": {
-          "title": "Exámenes Médicos de la FAA (2da y 3ra Clase, Sin Basic Med)",
+          "title": "Exámenes Médicos de la FAA (1ra, 2da y 3ra Clase, Sin Basic Med)",
           "shortDescription": "La Administración Federal de Aviación (FAA) exige que los pilotos estén certificados médicamente para la clase de certificado que desean. Esto permite identificar y tratar posibles problemas médicos para prevenir accidentes y mejorar la seguridad de la aviación.",
           "informationSection": {
             "whoApplies": {
@@ -487,8 +487,8 @@
                 ]
               },
               "faa": {
-                "title": "Examen Médico de Aviación de la FAA (2da y 3ra Clase)",
-                "description": "Examen de certificación médica de la Administración Federal de Aviación para pilotos privados y comerciales. Proporcionamos certificados médicos de 2da y 3ra clase.",
+                "title": "Examen Médico de Aviación de la FAA (1ra, 2da y 3ra Clase)",
+                "description": "Examen de certificación médica de la Administración Federal de Aviación para pilotos privados y comerciales. Proporcionamos certificados médicos de 1ra, 2da y 3ra clase.",
                 "remindersList": [
                   "Asegúrese de traer: Identificación con foto vigente (Licencia de conducir o Pasaporte), lentes de contacto/gafas (si aplica) – Si usa lentes de contacto, traiga un estuche para quitárselenos y poder revisar la visión sin corregir, audífonos (si aplica), expedientes médicos o legales pertinentes (si aplica), número de confirmación de MedXPress.",
                   "Asegúrese de actualizar su historial de salud y sus medicamentos actuales en MedXPress antes de su llegada.",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,19 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ]
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"]
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request updates both the English (`dictionaries/en.json`) and Spanish (`dictionaries/es.json`) language files to clarify that FAA physicals are available for 1st, 2nd, and 3rd class certifications, instead of only 2nd and 3rd class. The changes ensure consistency across all service descriptions, titles, and reminders.

FAA Physicals service updates:

* Updated the `FAAPhysicals` service label in the `services` section to include "1st, 2nd & 3rd Class, No Basic Med" in both English and Spanish. [[1]](diffhunk://#diff-1e5fcab5c6125a02263df4399183d09832a69d1c68e8ee5003f63f547886d7bfL35-R35) [[2]](diffhunk://#diff-2aa2d62d783b98d1a39846f1572ab644d6d0061325c4e29aae8de8634eec0209L35-R35)
* Changed the `faaPhysicals` service title and descriptions throughout the files to reflect the inclusion of 1st class medical certificates. [[1]](diffhunk://#diff-1e5fcab5c6125a02263df4399183d09832a69d1c68e8ee5003f63f547886d7bfL82-R82) [[2]](diffhunk://#diff-1e5fcab5c6125a02263df4399183d09832a69d1c68e8ee5003f63f547886d7bfL189-R189) [[3]](diffhunk://#diff-1e5fcab5c6125a02263df4399183d09832a69d1c68e8ee5003f63f547886d7bfL490-R491) [[4]](diffhunk://#diff-2aa2d62d783b98d1a39846f1572ab644d6d0061325c4e29aae8de8634eec0209L82-R82) [[5]](diffhunk://#diff-2aa2d62d783b98d1a39846f1572ab644d6d0061325c4e29aae8de8634eec0209L189-R189) [[6]](diffhunk://#diff-2aa2d62d783b98d1a39846f1572ab644d6d0061325c4e29aae8de8634eec0209L490-R491)

Service details and reminders:

* Updated the `faa` examination section titles and descriptions to specify that 1st, 2nd, and 3rd class medical certificates are provided, and adjusted the reminders accordingly in both languages. [[1]](diffhunk://#diff-1e5fcab5c6125a02263df4399183d09832a69d1c68e8ee5003f63f547886d7bfL490-R491) [[2]](diffhunk://#diff-2aa2d62d783b98d1a39846f1572ab644d6d0061325c4e29aae8de8634eec0209L490-R491)