### PR TITLE
[fix] Only include "online bookable services" in services list

### DIFF
--- a/app/api/catalog/services/route.ts
+++ b/app/api/catalog/services/route.ts
@@ -16,10 +16,14 @@ export async function GET(): Promise<NextResponse<ServiceTypeResponse[] | { erro
       id: item.itemData.variations[0].id,
       name: item.itemData.name,
       variationVersion: item.itemData.variations[0].version,
+      isBookable: item.itemData.variations[0].itemVariationData.availableForBooking,
     }));
 
-    const formattedServices = services.map((service) => ({
-      ...service,
+    const filteredServices = services.filter((service) => service.isBookable == true);
+
+    const formattedServices = filteredServices.map((service) => ({
+      id: service.id,
+      name: service.name,
       variationVersion: service.variationVersion ? service.variationVersion.toString() : undefined,
     }));
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request updates the `GET` endpoint in `app/api/catalog/services/route.ts` to ensure only bookable services are returned in the response. The main change is the introduction of a new `isBookable` property and filtering logic to exclude services that are not available for booking.

Filtering and response formatting improvements:

* Added the `isBookable` property to each service by reading `itemVariationData.availableForBooking` from the item variation data.
* Updated the logic to filter out services that are not bookable, ensuring only services with `isBookable == true` are included in the response.
* Modified the formatting step to operate on the filtered list, returning only relevant fields for bookable services.