### PR TITLE
[add] Add service reminders and show in booking form

### DIFF
--- a/app/[lang]/(appointments)/schedule-appointment/_components/schedule-appointment-form.tsx
+++ b/app/[lang]/(appointments)/schedule-appointment/_components/schedule-appointment-form.tsx
@@ -12,6 +12,7 @@ import "react-datepicker/dist/react-datepicker.css";
 
 import Link from "next/link";
 
+import { getServiceReminderKey } from "@/lib/service-reminders";
 import { ServiceTypeResponse } from "@/lib/types/api/services";
 import { SupportedLanguagesProps } from "@/lib/types/supported-languages";
 import { getDictionary } from "@/lib/utils/dictionaries";
@@ -39,6 +40,7 @@ const ScheduleAppointmentForm = ({ params }: SupportedLanguagesProps) => {
   // Appointment Information
   const [selectedAppointmentType, setSelectedAppointmentType] = useState("");
   const [selectedAppointmentVariationVersion, setSelectedAppointmentVariationVersion] = useState<number | null>(null);
+  const [serviceReminderKey, setServiceReminderKey] = useState<string | null>(null);
   const [newOrReturningClient, setNewOrReturningClients] = useState("");
   const [newHealthConditions, setNewHealthConditions] = useState("");
   const [newMedications, setNewMedications] = useState("");
@@ -176,6 +178,8 @@ const ScheduleAppointmentForm = ({ params }: SupportedLanguagesProps) => {
       setSelectedBookingDate(null);
       setSelectedTime("");
       setAvailableTimes([]);
+      const reminderKey = getServiceReminderKey(selectedService.name);
+      setServiceReminderKey(reminderKey);
     }
   };
 
@@ -666,6 +670,30 @@ const ScheduleAppointmentForm = ({ params }: SupportedLanguagesProps) => {
                   ))}
                 </select>
               </div>
+
+              {/* Service-specific reminder */}
+              {serviceReminderKey &&
+                dict?.pages.scheduleAppointment.scheduleForm.steps.appointmentInfoStep.serviceReminders[
+                  serviceReminderKey
+                ] && (
+                  <div className="bg-amber-900/50 border-l-4 border-amber-400 p-4 rounded">
+                    <h3 className="font-bold text-xl text-amber-300 mb-2">
+                      {
+                        dict.pages.scheduleAppointment.scheduleForm.steps.appointmentInfoStep.serviceReminders[
+                          serviceReminderKey
+                        ].title
+                      }
+                    </h3>
+                    <p className="text-white text-base">
+                      {
+                        dict.pages.scheduleAppointment.scheduleForm.steps.appointmentInfoStep.serviceReminders[
+                          serviceReminderKey
+                        ].message
+                      }
+                    </p>
+                  </div>
+                )}
+
               <div>
                 <label className="block text-white text-lg font-semibold mb-2" htmlFor="newOrReturningClient">
                   {dict.pages.scheduleAppointment.scheduleForm.steps.appointmentInfoStep.newOrReturningClient.label}

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -419,6 +419,24 @@
                   "Consultations will be billed by time spent during the consultation. Time spent by Dr. Quigley making phone calls on your behalf or reviewing your medical or legal records after a consultation or medical examination will also be billed."
                 ]
               }
+            },
+            "serviceReminders": {
+              "faaFirst": {
+                "title": "IMPORTANT REMINDER:",
+                "message": "Be sure to update your health history and current medications in MedXPress prior to your appointment."
+              },
+              "faaSecondThird": {
+                "title": "IMPORTANT REMINDER:",
+                "message": "Be sure to update your health history and current medications in MedXPress prior to your appointment."
+              },
+              "dot": {
+                "title": "IMPORTANT REMINDER:",
+                "message": "Be sure to complete the driver information and health history sections on the Medical Examination Report Form (MCSA-5875) prior to your appointment."
+              },
+              "immigration": {
+                "title": "IMPORTANT REMINDER:",
+                "message": "Be sure to complete parts 1-4 on pages 1-3 of Form I-693 prior to your appointment."
+              }
             }
           },
           "calendarBookingStep": {

--- a/dictionaries/es.json
+++ b/dictionaries/es.json
@@ -419,6 +419,24 @@
                   "Las consultas se facturarán según el tiempo dedicado durante la consulta. El tiempo que la Dra. Quigley dedique a hacer llamadas telefónicas en su nombre o a revisar sus expedientes médicos o legales después de una consulta o un examen médico también se facturará."
                 ]
               }
+            },
+            "serviceReminders": {
+              "faaFirst": {
+                "title": "RECORDATORIO IMPORTANTE:",
+                "message": "Asegúrese de actualizar su historial de salud y sus medicamentos actuales en MedXPress antes de su cita."
+              },
+              "faaSecondThird": {
+                "title": "RECORDATORIO IMPORTANTE:",
+                "message": "Asegúrese de actualizar su historial de salud y sus medicamentos actuales en MedXPress antes de su cita."
+              },
+              "dot": {
+                "title": "RECORDATORIO IMPORTANTE:",
+                "message": "Asegúrese de completar las secciones de información del conductor e historial de salud en el Formulario de Informe de Examen Médico (MCSA-5875) antes de su cita."
+              },
+              "immigration": {
+                "title": "RECORDATORIO IMPORTANTE:",
+                "message": "Asegúrese de completar las partes 1 a 4 en las páginas 1 a 3 del Formulario I-693 antes de su cita."
+              }
             }
           },
           "calendarBookingStep": {

--- a/lib/service-reminders.ts
+++ b/lib/service-reminders.ts
@@ -1,0 +1,52 @@
+/**
+ * Configuration object for service reminders.
+ * @interface ServiceReminderConfig
+ * @property {string | RegExp} namePattern - A string or regular expression pattern used to match service names.
+ * @property {string} dictionaryKey - The key used to retrieve reminder text from a localization dictionary.
+ */
+export interface ServiceReminderConfig {
+  namePattern: string | RegExp;
+  dictionaryKey: string;
+}
+
+export const SERVICE_REMINDER_CONFIGS: ServiceReminderConfig[] = [
+  {
+    namePattern: /FAA.*1st|FAA.*First/i,
+    dictionaryKey: "faaFirst",
+  },
+  {
+    namePattern: /FAA.*(2nd|3rd|Second|Third)/i,
+    dictionaryKey: "faaSecondThird",
+  },
+  {
+    namePattern: /DOT/i,
+    dictionaryKey: "dot",
+  },
+  {
+    namePattern: /Immigration/i,
+    dictionaryKey: "immigration",
+  },
+];
+
+/**
+ * Gets the dictionary key for the reminder based on service name
+ * @param serviceName - The name of the service from Square
+ * @returns The dictionary key for the matching reminder, or null if no match found
+ */
+export function getServiceReminderKey(serviceName: string): string | null {
+  if (!serviceName) return null;
+
+  for (const config of SERVICE_REMINDER_CONFIGS) {
+    if (typeof config.namePattern === "string") {
+      if (serviceName.toLowerCase().includes(config.namePattern.toLowerCase())) {
+        return config.dictionaryKey;
+      }
+    } else if (config.namePattern instanceof RegExp) {
+      if (config.namePattern.test(serviceName)) {
+        return config.dictionaryKey;
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request adds support for displaying service-specific appointment reminders in the scheduling form, based on the selected service. The reminders are localized and configurable, ensuring users see important instructions relevant to their appointment type.

Service-specific reminder logic:

* Introduced a new utility (`lib/service-reminders.ts`) that maps service names to reminder dictionary keys using patterns, and exports a `getServiceReminderKey` function to retrieve the appropriate key for a given service.
* Updated `schedule-appointment-form.tsx` to use `getServiceReminderKey` when a service is selected, storing the result in state and conditionally rendering a reminder box if a matching reminder is found in the dictionary. ([app/[lang]/(appointments)/schedule-appointment/_components/schedule-appointment-form.tsxR15](diffhunk://#diff-e44257d4f7c400aa5a7dbdc649f4d45b882aef6395f3b8e822d5b4c37cd62bf2R15), [app/[lang]/(appointments)/schedule-appointment/_components/schedule-appointment-form.tsxR43](diffhunk://#diff-e44257d4f7c400aa5a7dbdc649f4d45b882aef6395f3b8e822d5b4c37cd62bf2R43), [app/[lang]/(appointments)/schedule-appointment/_components/schedule-appointment-form.tsxR181-R182](diffhunk://#diff-e44257d4f7c400aa5a7dbdc649f4d45b882aef6395f3b8e822d5b4c37cd62bf2R181-R182), [app/[lang]/(appointments)/schedule-appointment/_components/schedule-appointment-form.tsxR673-R696](diffhunk://#diff-e44257d4f7c400aa5a7dbdc649f4d45b882aef6395f3b8e822d5b4c37cd62bf2R673-R696))

Localization:

* Added `serviceReminders` sections to both `en.json` and `es.json` dictionaries, providing localized titles and messages for FAA, DOT, and Immigration service types. [[1]](diffhunk://#diff-1e5fcab5c6125a02263df4399183d09832a69d1c68e8ee5003f63f547886d7bfR422-R439) [[2]](diffhunk://#diff-2aa2d62d783b98d1a39846f1572ab644d6d0061325c4e29aae8de8634eec0209R422-R439)