### PR TITLE
[fix] Fix Appointment Confirmation Wording and Functionality

### DIFF
--- a/app/[lang]/(appointments)/schedule-appointment/appointment-confirmed/_components/appointment-confirmed-content.tsx
+++ b/app/[lang]/(appointments)/schedule-appointment/appointment-confirmed/_components/appointment-confirmed-content.tsx
@@ -97,75 +97,63 @@ const AppointmentConfirmedContent = ({ params }: SupportedLanguagesProps) => {
   };
 
   const getAppointmentTypeInfo = (appointmentType: string) => {
-    const appointmentInfo: Record<
-      string,
+    // Configuration array similar to service-reminders.ts
+    const appointmentTypeConfigs = [
       {
-        title: string;
-        description: string;
-        reminders?: string[];
-        servicePageUrl?: string;
-      }
-    > = {
-      "DOT Physicals": {
-        title: dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.dot.title,
-        description:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.dot
-            .description,
-        reminders:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.dot
-            .remindersList,
+        pattern: /DOT/i,
+        dictionaryKey: "dot",
         servicePageUrl: "/services/dot-physicals",
       },
-      "FAA Physicals (2nd & 3rd Class)": {
-        title: dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.faa.title,
-        description:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.faa
-            .description,
-        reminders:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.faa
-            .remindersList,
+      {
+        pattern: /FAA/i,
+        dictionaryKey: "faa",
         servicePageUrl: "/services/faa-physicals",
       },
-      "School/Sports/Camp Physicals": {
-        title:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes
-            .schoolSportsCamp.title,
-        description:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes
-            .schoolSportsCamp.description,
-        reminders:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes
-            .schoolSportsCamp.remindersList,
+      {
+        pattern: /School|Sports|Camp/i,
+        dictionaryKey: "schoolSportsCamp",
         servicePageUrl: "/services/school-sports-camp-physicals",
       },
-      Consultation: {
-        title:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.consultation
-            .title,
-        description:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.consultation
-            .description,
-        reminders:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.consultation
-            .remindersList,
+      {
+        pattern: /Immigration/i,
+        dictionaryKey: "immigration",
+        servicePageUrl: "/services/immigration",
+      },
+      {
+        pattern: /Consultation/i,
+        dictionaryKey: "consultation",
         servicePageUrl: "/services",
       },
-    };
+    ];
 
-    // Return the matching appointment type or a default
-    return (
-      appointmentInfo[appointmentType] || {
-        title:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.general.title,
-        description:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.general
-            .description,
-        reminders:
-          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.general
-            .remindersList,
-        servicePageUrl: "/services",
+    // Try to find a matching pattern
+    for (const config of appointmentTypeConfigs) {
+      if (config.pattern.test(appointmentType)) {
+        const serviceData =
+          dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes[
+            config.dictionaryKey
+          ];
+        return {
+          title: serviceData.title,
+          description: serviceData.description,
+          reminders: serviceData.remindersList,
+          servicePageUrl: config.servicePageUrl,
+        };
       }
-    );
+    }
+
+    // Default fallback
+    return {
+      title:
+        dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.general.title,
+      description:
+        dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.general
+          .description,
+      reminders:
+        dict.pages.scheduleAppointment.appointmentConfirmed.whatToExpectSection.reminders.serviceTypes.general
+          .remindersList,
+      servicePageUrl: "/services",
+    };
   };
 
   if (!dict || bookingLoading) {

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -498,20 +498,24 @@
                 "title": "DOT Physical Examination",
                 "description": "A Department of Transportation (DOT) physical examination to ensure you meet the health standards required for commercial driving.",
                 "remindersList": [
-                  "Make sure to bring: Medical Examination Report (MER) Form, Current state-issued driver’s license, Contacts/glasses (if applicable) – If you wear contacts, bring a contact case to remove contacts to check uncorrected vision, Hearing aids (if applicable), List of current medications with dosages and prescriber’s name, Special circumstances or exemption letters from your doctor(s) and/or pertinent medical or legal records (if applicable)",
+                  "Make sure to bring: Medical Examination Report (MER) Form, Current state-issued driver's license, Contacts/glasses (if applicable), Hearing aids (if applicable), List of current medications with dosages and prescriber's name, Special circumstances or exemption letters, clearance letters from your doctor(s) and/or pertinent medical or legal records (if applicable)",
                   "Be sure to complete the driver information and health history sections on the first two pages of the Medical Examination Report Form (MCSA-5875) prior to your appointment.",
-                  "You do NOT need to be fasting for your appointment, but you will need to leave a urine sample at the beginning of your appointment.",
-                  "Please show up to your appointment 10-15 minutes early to check in, leave a urine sample, and be ready for your appointment on time."
+                  "If you arrive at your appointment unprepared, you will be charged an additional fee.",
+                  "You do NOT need to be fasting for your appointment, but you will need to leave a urine sample.",
+                  "Please show up to your appointment 15 minutes early to check in and be ready for your appointment on time.",
+                  "If you arrive late for your appointment, you may have to reschedule and will be charged a late cancellation fee."
                 ]
               },
               "faa": {
                 "title": "FAA Aviation Medical Examination (1st, 2nd & 3rd Class)",
                 "description": "Federal Aviation Administration medical certification examination for private and commercial pilots. We provide 1st, 2nd, and 3rd class medical certificates.",
                 "remindersList": [
-                  "Make sure to bring: Current photo ID (Driver’s license or Passport), Contacts/glasses (if applicable) – If you wear contacts, bring a contact case to remove contacts to check uncorrected vision, Hearing aids (if applicable), Pertinent medical or legal records (if applicable), MedXPress confirmation number",
+                  "Make sure to bring: Current photo ID (Driver's license or Passport), Contacts/glasses (if applicable), Hearing aids (if applicable), Pertinent medical or legal records (if applicable), MedXPress confirmation number",
                   "Be sure to update your health history and current medications in MedXPress prior to your arrival.",
-                  "You do NOT need to be fasting for your appointment, but you will need to leave a urine sample at the beginning of your appointment.",
-                  "Please show up to your appointment 10-15 minutes early to check in, leave a urine sample, and be ready for your appointment on time."
+                  "If you arrive at your appointment unprepared, you will be charged an additional fee.",
+                  "You do NOT need to be fasting for your appointment, but you will need to leave a urine sample.",
+                  "Please show up to your appointment 10 minutes early to check in and be ready for your appointment on time.",
+                  "If you arrive late for your appointment, you may have to reschedule and will be charged a late cancellation fee."
                 ]
               },
               "schoolSportsCamp": {
@@ -520,38 +524,39 @@
                 "remindersList": [
                   "Make sure to bring: Any forms provided by your school, sports program, or camp that need to be completed and/or signed by Dr. Quigley, Immunization records, List of allergies and current medications with dosages (prescription and over-the-counter), List of past injuries and surgeries and pertinent family history",
                   "Be sure to complete any parts of participation forms that are to be completed by the client or their parent/guardian",
-                  "You do NOT need to be fasting for your appointment, but you will need to leave a urine sample at the beginning of your appointment if your participation form requires a urinalysis.",
-                  "Please show up to your appointment 10-15 minutes early to check in, leave a urine sample if necessary, and be ready for your appointment on time."
+                  "You do NOT need to be fasting for your appointment, but you may need to leave a urine sample if your participation form requires a urinalysis.",
+                  "Please show up to your appointment 10-15 minutes early to check in and be ready for your appointment on time.",
+                  "If you arrive late for your appointment, you may have to reschedule and will be charged a late cancellation fee."
                 ]
               },
               "immigration": {
                 "title": "Immigration Medical Examination",
                 "description": "USCIS-required medical examination for immigration and adjustment of status applications. This exam includes a review of vaccination records, medical history, and a physical examination.",
                 "remindersList": [
-                  "Make sure to bring: Valid passport or other government-issued photo ID, Form I-693 (Report of Medical Examination and Vaccination Record), Vaccination records, List of current medications",
+                  "Make sure to bring: Valid passport or other government-issued photo ID, Form I-693 (Report of Medical Examination and Vaccination Record), Vaccination records, List of current medications, Insurance information, Any pertinent medical records",
+                  "If you arrive at your appointment unprepared, you will be charged an additional fee.",
                   "As of December 2, 2024, USCIS requires Form I-693 to be submitted with your Form I-485. If you do not submit Form I-693 with your adjustment of status application package, USCIS may reject your entire application.",
                   "You do NOT need to be fasting for your appointment, but you may need to leave a urine sample.",
-                  "Please show up to your appointment 10-15 minutes early to check in and be ready for your appointment on time."
+                  "Please show up to your appointment 15 minutes early to check in and be ready for your appointment on time.",
+                  "If you arrive late for your appointment, you may have to reschedule and will be charged a late cancellation fee."
                 ]
               },
               "consultation": {
                 "title": "Consultation",
                 "description": "A consultation appointment to discuss your upcoming medical examination, review medical history, and address any concerns or questions you may have.",
                 "remindersList": [
-                  "Please bring a photo identification.",
-                  "Please bring your insurance information.",
-                  "Please bring a list of current medications.",
-                  "If you need to cancel or reschedule, please call at least 24 hours in advance"
+                  "Please bring a photo ID, medication list, and any pertinent medical records to discuss.",
+                  "Please show up to your appointment 10 minutes early to check in and be ready for your appointment on time.",
+                  "If you arrive late for your appointment, you may have to reschedule and will be charged a late cancellation fee."
                 ]
               },
               "general": {
                 "title": "General Appointment",
                 "description": "Your appointment has been confirmed. Please arrive 15 minutes early to complete any necessary paperwork.",
                 "remindersList": [
-                  "Please bring a photo identification.",
-                  "Please bring your insurance information.",
-                  "Please bring a list of current medications.",
-                  "If you need to cancel or reschedule, please call at least 24 hours in advance"
+                  "Please bring a photo ID, medication list, and any pertinent medical records to discuss.",
+                  "Please show up to your appointment 10 minutes early to check in and be ready for your appointment on time.",
+                  "If you arrive late for your appointment, you may have to reschedule and will be charged a late cancellation fee."
                 ]
               }
             },

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -524,6 +524,16 @@
                   "Please show up to your appointment 10-15 minutes early to check in, leave a urine sample if necessary, and be ready for your appointment on time."
                 ]
               },
+              "immigration": {
+                "title": "Immigration Medical Examination",
+                "description": "USCIS-required medical examination for immigration and adjustment of status applications. This exam includes a review of vaccination records, medical history, and a physical examination.",
+                "remindersList": [
+                  "Make sure to bring: Valid passport or other government-issued photo ID, Form I-693 (Report of Medical Examination and Vaccination Record), Vaccination records, List of current medications",
+                  "As of December 2, 2024, USCIS requires Form I-693 to be submitted with your Form I-485. If you do not submit Form I-693 with your adjustment of status application package, USCIS may reject your entire application.",
+                  "You do NOT need to be fasting for your appointment, but you may need to leave a urine sample.",
+                  "Please show up to your appointment 10-15 minutes early to check in and be ready for your appointment on time."
+                ]
+              },
               "consultation": {
                 "title": "Consultation",
                 "description": "A consultation appointment to discuss your upcoming medical examination, review medical history, and address any concerns or questions you may have.",

--- a/dictionaries/es.json
+++ b/dictionaries/es.json
@@ -498,20 +498,24 @@
                 "title": "Examen Físico del DOT",
                 "description": "Un examen físico del Departamento de Transporte (DOT) para asegurar que cumple con los estándares de salud requeridos para la conducción comercial.",
                 "remindersList": [
-                  "Asegúrese de traer: Formulario de Informe de Examen Médico (MER), licencia de conducir vigente emitida por el estado, lentes de contacto/gafas (si aplica) – Si usa lentes de contacto, traiga un estuche para quitárselos y poder revisar la visión sin corregir, audífonos (si aplica), lista de medicamentos actuales con dosis y el nombre de quien los recetó, cualquier circunstancia especial o carta de exención de su(s) médico(s) y/o expedientes médicos o legales pertinentes (si aplica).",
+                  "Asegúrese de traer: Formulario de Informe de Examen Médico (MER), licencia de conducir vigente emitida por el estado, lentes de contacto/gafas (si aplica), audífonos (si aplica), lista de medicamentos actuales con dosis y el nombre de quien los recetó, cartas de circunstancias especiales o exención, cartas de autorización de su(s) médico(s) y/o expedientes médicos o legales pertinentes (si aplica).",
                   "Asegúrese de completar las secciones de información del conductor e historial de salud en las dos primeras páginas del Formulario de Informe de Examen Médico (MCSA-5875) antes de su cita.",
-                  "NO necesita estar en ayunas para su cita, pero deberá dejar una muestra de orina al comienzo de su cita.",
-                  "Por favor, llegue a su cita con 10-15 minutos de antelación para registrarse, dejar una muestra de orina y estar listo para su cita a tiempo."
+                  "Si llega a su cita sin la preparación necesaria, se le cobrará un cargo adicional.",
+                  "NO necesita estar en ayunas para su cita, pero deberá dejar una muestra de orina.",
+                  "Por favor, llegue a su cita 15 minutos antes para registrarse y estar listo para su cita a tiempo.",
+                  "Si llega tarde a su cita, es posible que deba reprogramarla y se le cobrará un cargo por cancelación tardía."
                 ]
               },
               "faa": {
-                "title": "Examen Médico de Aviación de la FAA (1ra, 2da y 3ra Clase)",
-                "description": "Examen de certificación médica de la Administración Federal de Aviación para pilotos privados y comerciales. Proporcionamos certificados médicos de 1ra, 2da y 3ra clase.",
+                "title": "Examen Médico de Aviación de la FAA (1.ª, 2.ª y 3.ª Clase)",
+                "description": "Examen de certificación médica de la Administración Federal de Aviación para pilotos privados y comerciales. Proporcionamos certificados médicos de 1.ª, 2.ª y 3.ª clase.",
                 "remindersList": [
-                  "Asegúrese de traer: Identificación con foto vigente (Licencia de conducir o Pasaporte), lentes de contacto/gafas (si aplica) – Si usa lentes de contacto, traiga un estuche para quitárselenos y poder revisar la visión sin corregir, audífonos (si aplica), expedientes médicos o legales pertinentes (si aplica), número de confirmación de MedXPress.",
+                  "Asegúrese de traer: Identificación con foto vigente (Licencia de conducir o Pasaporte), lentes de contacto/gafas (si aplica), audífonos (si aplica), expedientes médicos o legales pertinentes (si aplica), número de confirmación de MedXPress.",
                   "Asegúrese de actualizar su historial de salud y sus medicamentos actuales en MedXPress antes de su llegada.",
-                  "NO necesita estar en ayunas para su cita, pero deberá dejar una muestra de orina al comienzo de su cita.",
-                  "Por favor, llegue a su cita con 10-15 minutos de antelación para registrarse, dejar una muestra de orina y estar listo para su cita a tiempo."
+                  "Si llega a su cita sin la preparación necesaria, se le cobrará un cargo adicional.",
+                  "NO necesita estar en ayunas para su cita, pero deberá dejar una muestra de orina.",
+                  "Por favor, llegue a su cita 10 minutos antes para registrarse y estar listo para su cita a tiempo.",
+                  "Si llega tarde a su cita, es posible que deba reprogramarla y se le cobrará un cargo por cancelación tardía."
                 ]
               },
               "schoolSportsCamp": {
@@ -520,38 +524,39 @@
                 "remindersList": [
                   "Asegúrese de traer: Cualquier formulario proporcionado por su escuela, programa deportivo o campamento que deba ser completado y/o firmado por la Dra. Quigley, registros de inmunización, lista de alergias y medicamentos actuales con dosis (recetados y de venta libre), lista de lesiones y cirugías pasadas e historial familiar pertinente.",
                   "Asegúrese de completar cualquier parte de los formularios de participación que deba ser llenada por el paciente o su padre/tutor.",
-                  "NO necesita estar en ayunas para su cita, pero deberá dejar una muestra de orina al comienzo de su cita si su formulario de participación requiere un análisis de orina.",
-                  "Por favor, llegue a su cita con 10-15 minutos de antelación para registrarse, dejar una muestra de orina si es necesario y estar listo para su cita a tiempo."
+                  "NO necesita estar en ayunas para su cita, pero es posible que deba dejar una muestra de orina si su formulario de participación requiere un análisis de orina.",
+                  "Por favor, llegue a su cita con 10-15 minutos de antelación para registrarse y estar listo para su cita a tiempo.",
+                  "Si llega tarde a su cita, es posible que deba reprogramarla y se le cobrará un cargo por cancelación tardía."
                 ]
               },
               "immigration": {
                 "title": "Examen Médico de Inmigración",
                 "description": "Examen médico requerido por el USCIS para solicitudes de inmigración y ajuste de estatus. Este examen incluye una revisión de los registros de vacunación, historial médico y un examen físico.",
                 "remindersList": [
-                  "Asegúrese de traer: Pasaporte válido u otra identificación con foto emitida por el gobierno, Formulario I-693 (Informe de Examen Médico y Registro de Vacunación), registros de vacunación, lista de medicamentos actuales",
+                  "Asegúrese de traer: Pasaporte válido u otra identificación con foto emitida por el gobierno, Formulario I-693 (Informe de Examen Médico y Registro de Vacunación), registros de vacunación, lista de medicamentos actuales, información del seguro, cualquier registro médico pertinente.",
+                  "Si llega a su cita sin la preparación necesaria, se le cobrará un cargo adicional.",
                   "A partir del 2 de diciembre de 2024, el USCIS requiere que el Formulario I-693 se presente junto con su Formulario I-485. Si no presenta el Formulario I-693 con su paquete de solicitud de ajuste de estatus, el USCIS puede rechazar su solicitud por completo.",
                   "NO necesita estar en ayunas para su cita, pero es posible que deba dejar una muestra de orina.",
-                  "Por favor, llegue a su cita con 10-15 minutos de antelación para registrarse y estar listo para su cita a tiempo."
+                  "Por favor, llegue a su cita 15 minutos antes para registrarse y estar listo para su cita a tiempo.",
+                  "Si llega tarde a su cita, es posible que deba reprogramarla y se le cobrará un cargo por cancelación tardía."
                 ]
               },
               "consultation": {
                 "title": "Consulta",
                 "description": "Una cita de consulta para discutir su próximo examen médico, revisar el historial médico y abordar cualquier inquietud o pregunta que pueda tener.",
                 "remindersList": [
-                  "Por favor, traiga una identificación con fotografía.",
-                  "Por favor, traiga la información de su seguro.",
-                  "Por favor, traiga una lista de sus medicamentos actuales.",
-                  "Si necesita cancelar o reprogramar, por favor llame con al menos 24 horas de antelación."
+                  "Por favor, traiga una identificación con foto, lista de medicamentos y cualquier registro médico pertinente para discutir.",
+                  "Por favor, llegue a su cita 10 minutos antes para registrarse y estar listo para su cita a tiempo.",
+                  "Si llega tarde a su cita, es posible que deba reprogramarla y se le cobrará un cargo por cancelación tardía."
                 ]
               },
               "general": {
                 "title": "Cita General",
                 "description": "Su cita ha sido confirmada. Por favor, llegue 15 minutos antes para completar cualquier papeleo necesario.",
                 "remindersList": [
-                  "Por favor, traiga una identificación con fotografía.",
-                  "Por favor, traiga la información de su seguro.",
-                  "Por favor, traiga una lista de sus medicamentos actuales.",
-                  "Si necesita cancelar o reprogramar, por favor llame con al menos 24 horas de antelación."
+                  "Por favor, traiga una identificación con foto, lista de medicamentos y cualquier registro médico pertinente para discutir.",
+                  "Por favor, llegue a su cita 10 minutos antes para registrarse y estar listo para su cita a tiempo.",
+                  "Si llega tarde a su cita, es posible que deba reprogramarla y se le cobrará un cargo por cancelación tardía."
                 ]
               }
             },

--- a/dictionaries/es.json
+++ b/dictionaries/es.json
@@ -524,6 +524,16 @@
                   "Por favor, llegue a su cita con 10-15 minutos de antelación para registrarse, dejar una muestra de orina si es necesario y estar listo para su cita a tiempo."
                 ]
               },
+              "immigration": {
+                "title": "Examen Médico de Inmigración",
+                "description": "Examen médico requerido por el USCIS para solicitudes de inmigración y ajuste de estatus. Este examen incluye una revisión de los registros de vacunación, historial médico y un examen físico.",
+                "remindersList": [
+                  "Asegúrese de traer: Pasaporte válido u otra identificación con foto emitida por el gobierno, Formulario I-693 (Informe de Examen Médico y Registro de Vacunación), registros de vacunación, lista de medicamentos actuales",
+                  "A partir del 2 de diciembre de 2024, el USCIS requiere que el Formulario I-693 se presente junto con su Formulario I-485. Si no presenta el Formulario I-693 con su paquete de solicitud de ajuste de estatus, el USCIS puede rechazar su solicitud por completo.",
+                  "NO necesita estar en ayunas para su cita, pero es posible que deba dejar una muestra de orina.",
+                  "Por favor, llegue a su cita con 10-15 minutos de antelación para registrarse y estar listo para su cita a tiempo."
+                ]
+              },
               "consultation": {
                 "title": "Consulta",
                 "description": "Una cita de consulta para discutir su próximo examen médico, revisar el historial médico y abordar cualquier inquietud o pregunta que pueda tener.",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have tested my changes locally and they work
- [x] My pull request targets the `main` branch of this repository.
- [x] I have organized any project files to the best of my ability

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
This pull request improves the logic for displaying appointment confirmation details and updates the appointment reminder content for both English and Spanish. The main changes include refactoring how appointment types are matched to their information, adding support for immigration medical exams, and standardizing and expanding the reminders for all appointment types to provide clearer instructions and consequences for late or unprepared arrivals.

**Appointment type matching and logic improvements:**
- Refactored the `getAppointmentTypeInfo` function in `appointment-confirmed-content.tsx` to use a configuration array with regex patterns for matching appointment types, making it easier to add new types and improving maintainability. Added support for "Immigration" appointment type. ([app/[lang]/(appointments)/schedule-appointment/appointment-confirmed/_components/appointment-confirmed-content.tsxL100-R146](diffhunk://#diff-db6f0d8fca2548cce6abc0915799c413496fa254466153fd59079cd2668eb941L100-R146))
- Improved fallback logic for unmatched appointment types to ensure a default reminder is always provided. ([app/[lang]/(appointments)/schedule-appointment/appointment-confirmed/_components/appointment-confirmed-content.tsxL167-R156](diffhunk://#diff-db6f0d8fca2548cce6abc0915799c413496fa254466153fd59079cd2668eb941L167-R156))

**Content and reminders updates (English):**
- Updated and standardized reminder lists for all appointment types in `en.json`, providing clearer instructions (e.g., what to bring, arrival times), and added explicit warnings about fees for being unprepared or late.
- Added new content for "Immigration Medical Examination" with specific reminders and requirements.

**Content and reminders updates (Spanish):**
- Updated and standardized reminder lists for all appointment types in `es.json` to match the new English content, ensuring consistency and clarity.
- Added new content for "Examen Médico de Inmigración" with detailed reminders and requirements.